### PR TITLE
Fixed a corner case bug with clear()

### DIFF
--- a/src/main/java/com/zaxxer/sparsebits/SparseBitSet.java
+++ b/src/main/java/com/zaxxer/sparsebits/SparseBitSet.java
@@ -563,7 +563,7 @@ public class SparseBitSet implements Cloneable, Serializable
             in some later operation. */
         if ((i + 1) < 1)
             throw new IndexOutOfBoundsException("i=" + i);
-        if (i > bitsLength)
+        if (i >= bitsLength)
             return;
         final int w = i >> SHIFT3;
         long[][] a2;


### PR DESCRIPTION
Noticed this occurring when using `SparseBitSet` for larger instances. All other comparisons to `bitsLength` are `>=`, too (see e.g. `flip`).