### PR TITLE
[#15] previousSetBit resets word length after miss

### DIFF
--- a/src/test/java/com/zaxxer/sparsebits/PreviousClearBitTest.java
+++ b/src/test/java/com/zaxxer/sparsebits/PreviousClearBitTest.java
@@ -206,4 +206,14 @@ public class PreviousClearBitTest extends Assert {
             values.clear();
         }
     }
+
+    @Test
+    public void bug15() throws Exception {
+        set.set(1);
+        set.set(64);
+        assertEquals(63, set.previousClearBit(64));
+        set.clear(0);
+        set.set(1);
+        assertEquals(63, set.previousClearBit(64));
+    }
 }


### PR DESCRIPTION
Currently it sets the length to the position of the needle in the first
word it looks up and only searches indices below that. This is incorrect
after the initial word where we need to search from the top.