### PR TITLE
add Automatic-Module-Name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,17 @@
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <configuration>
+               <archive>
+                  <manifestEntries>
+                     <Automatic-Module-Name>com.zaxxer.sparsebitset</Automatic-Module-Name>
+                  </manifestEntries>
+               </archive>
+            </configuration>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
             <version>2.2.1</version>
             <configuration>


### PR DESCRIPTION
Relates to https://github.com/brettwooldridge/SparseBitSet/issues/21 - Automatic Module Name approach is easier to use than module-info and you don't need to build with Java 9+.