### PR TITLE
general cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SparseBitSet
 
 ### TL;DR
 Basically, if you need to set a large number of bits, or bits at extremely high offsets, you probably want to use this 
-Sparse BitSet.  All other alternatives are essentialy off the table; the Java BitSet class is a non-starter.  Performance
+Sparse BitSet.  All other alternatives are essentially off the table; the Java BitSet class is a non-starter.  Performance
 is superior in almost all cases to the standard Java BitSet.
 
 ### Preface

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
    <licenses>
       <license>
          <name>The Apache Software License, Version 2.0</name>
-         <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+         <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
          <distribution>repo</distribution>
       </license>
    </licenses>
@@ -43,14 +43,14 @@
    <parent>
       <groupId>org.sonatype.oss</groupId>
       <artifactId>oss-parent</artifactId>
-      <version>7</version>
+      <version>9</version>
    </parent>
 
    <dependencies>
       <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
-         <version>4.12</version>
+         <version>4.13.2</version>
          <scope>test</scope>
       </dependency>
    </dependencies>
@@ -62,16 +62,16 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.1</version>
+            <version>3.11.0</version>
             <configuration>
-               <source>1.5</source>
-               <target>1.5</target>
+               <source>1.7</source>
+               <target>1.7</target>
             </configuration>
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>2.2.1</version>
+            <version>3.3.0</version>
             <configuration>
                <attach>true</attach>
             </configuration>
@@ -87,10 +87,11 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.9.1</version>
+            <version>3.5.0</version>
             <configuration>
                <show>public</show>
                <attach>true</attach>
+               <source>7</source>
             </configuration>
             <executions>
                <execution>
@@ -117,7 +118,7 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-gpg-plugin</artifactId>
-                  <version>1.4</version>
+                  <version>1.6</version>
                   <executions>
                      <execution>
                         <id>sign-artifacts</id>

--- a/src/main/java/com/zaxxer/sparsebits/SparseBitSet.java
+++ b/src/main/java/com/zaxxer/sparsebits/SparseBitSet.java
@@ -31,7 +31,7 @@ import java.io.Serializable;
  *  <code>SparseBitSet</code> are labelled <code>
  *  0</code>&nbsp;..&nbsp;<code>Integer.MAX_VALUE&nbsp;&minus;&nbsp;1</code>.
  *  After the last set bit of a <code>SparseBitSet</code>, any attempt to find
- *  a subsequent bit (<i>nextSetBit</i>()), will return an value of &minus;1.
+ *  a subsequent bit (<i>nextSetBit</i>()), will return a value of &minus;1.
  *  If an attempt is made to use <i>nextClearBit</i>(), and all the bits are
  *  set from the starting position of the search to the bit labelled
  *  <code>Integer.MAX_VALUE&nbsp;&minus;&nbsp;1</code>, then similarly &minus;1
@@ -76,7 +76,7 @@ public class SparseBitSet implements Cloneable, Serializable
         scanning algorithms, meaning that the accesses are always nested three
         deep. Again, the change this might be a large amount of work. On the
         other hand, these three levels have proven, so far, to provide adequate
-        speed, and an storage efficient way to deal with sparseness.
+        speed, and a storage efficient way to deal with sparseness.
 
         For simplicity, the level3 blocks and the level2 areas are always "full"
         size, i.e., LENGTH3 and LENGTH2 respectively, and for consistency, the
@@ -99,7 +99,7 @@ public class SparseBitSet implements Cloneable, Serializable
         bits (setting, flipping, clearing, etc.) do not attempt to normalize the
         set, in the interests of speed. However, when a set is scanned as the
         resultant set of some operation, then, in most cases, the set will be
-        normalized--the exception being level2 areas that are not completly scanned
+        normalized--the exception being level2 areas that are not completely scanned
         in a particular pass.
 
         The sizes of the blocks and areas has been the result of some investigation
@@ -161,7 +161,6 @@ public class SparseBitSet implements Cloneable, Serializable
      *  4 "levels". Respectively (from the least significant end), level4, the
      *  address within word, the address within a level3 block, the address within
      *  a level2 area, and the level1 address of that area within the set.
-     *
      *  LEVEL4 is the number of bits of the level4 address (number of bits need
      *  to address the bits in a long)
      */
@@ -333,12 +332,12 @@ public class SparseBitSet implements Cloneable, Serializable
 
     /**
      *  Constructor for a new (sparse) bit set. All bits initially are effectively
-     *  <code>false</code>. This is a internal constructor that collects all the
+     *  <code>false</code>. This is an internal constructor that collects all the
      *  needed actions to initialise the bit set.
      *  <p>
      *  The capacity is taken to be a <i>suggestion</i> for a size of the bit set,
      *  in bits. An appropiate table size (a power of two) is then determined and
-     *  used. The size will be grown as needed to accomodate any bits addressed
+     *  used. The size will be grown as needed to accommodate any bits addressed
      *  during the use of the bit set.
      *
      * @param       capacity a size in terms of bits
@@ -529,7 +528,7 @@ public class SparseBitSet implements Cloneable, Serializable
     }
 
     /**
-     *  Creates a bit set from thie first <code>SparseBitSet</code> whose
+     *  Creates a bit set from the first <code>SparseBitSet</code> whose
      *  corresponding bits are cleared by the set bits of the second
      *  <code>SparseBitSet</code>. The resulting bit set is created so that a bit
      *  in it has the value <code>true</code> if and only if the corresponding bit
@@ -1225,7 +1224,7 @@ public class SparseBitSet implements Cloneable, Serializable
      *  Performs a logical <b>OR</b> of the two given <code>SparseBitSet</code>s.
      *  The returned <code>SparseBitSet</code> is created so that a bit in it has
      *  the value <code>true</code> if and only if it either had the value
-     *  <code>true</code> in the set given by the first arguemetn or had the value
+     *  <code>true</code> in the set given by the first argument or had the value
      *  <code>true</code> in the second argument, otherwise <code>false</code>.
      *
      * @param       a a SparseBitSet
@@ -1290,7 +1289,7 @@ public class SparseBitSet implements Cloneable, Serializable
      *  <code>j</code> (exclusive) to <code>true</code>.
      *
      * @param       i index of the first bit to be set
-     * @param       j index after the last bit to be se
+     * @param       j index after the last bit to be set
      * @exception   IndexOutOfBoundsException if <code>i</code> is negative or is
      *              equal to Integer.MAX_INT, or <code>j</code> is negative, or
      *              <code>i</code> is larger than <code>j</code>.
@@ -1354,7 +1353,7 @@ public class SparseBitSet implements Cloneable, Serializable
      *  include: Size, Length, Cardinality, Total words (<i>i.e.</i>, the total
      *  number of 64-bit "words"), Set array length (<i>i.e.</i>, the number of
      *  references that can be held by the top level array, Level2 areas in use,
-     *  Level3 blocks in use,, Level2 pool size, Level3 pool size, and the
+     *  Level3 blocks in use, Level2 pool size, Level3 pool size, and the
      *  Compaction count.
      *  <p>
      *  This method is intended for diagnostic use (as it is relatively expensive
@@ -1505,7 +1504,7 @@ public class SparseBitSet implements Cloneable, Serializable
     /** Sequences of set bits longer than this value are shown by
      *  {@link #toString()} as a "sub-sequence," in the form <code>a..b</code>.
      *  Setting this value to zero causes each set bit to be listed individually.
-     *  The default default value is 2 (which means sequences of three or more
+     *  The default value is 2 (which means sequences of three or more
      *  bits set are shown as a subsequence, and all other set bits are listed
      *  individually).
      *  <p>
@@ -1647,8 +1646,8 @@ public class SparseBitSet implements Cloneable, Serializable
      *  Throw the exception to indicate a range error. The <code>String</code>
      *  constructed reports all the possible errors in one message.
      *
-     * @param       i lower bound for a operation
-     * @param       j upper bound for a operation
+     * @param       i lower bound for an operation
+     * @param       j upper bound for an operation
      * @exception   IndexOutOfBoundsException indicating the range is not valid
      * @since       1.6
      */
@@ -1668,7 +1667,7 @@ public class SparseBitSet implements Cloneable, Serializable
     }
 
     /**
-     *  Intializes all the additional objects required for correct operation.
+     *  Initializes all the additional objects required for correct operation.
      *
      * @since       1.6
      */
@@ -1699,7 +1698,7 @@ public class SparseBitSet implements Cloneable, Serializable
     }
 
     /**
-     *  Resize the bit array. Moves the entries in the the bits array of this
+     *  Resize the bit array. Moves the entries in the bits array of this
      *  SparseBitSet into an array whose size (which may be larger or smaller) is
      *  the given bit size (<i>i.e.</i>, includes the bit whose index is one less
      *  that the given value). If the new array is smaller, the excess entries in
@@ -1921,7 +1920,7 @@ public class SparseBitSet implements Cloneable, Serializable
                         }
                         if (isZero) //  The resulting a3 block has no values
                         {// nested if!
-                            /*  If there is an level 2 area make the entry for this
+                            /*  If there is a level 2 area make the entry for this
                                 level3 block be a null (i.e., remove any a3 block ). */
                             if (haveA2)
                                 a2[u2] = null;
@@ -2183,7 +2182,7 @@ public class SparseBitSet implements Cloneable, Serializable
      *
      * @see     #statisticsUpdate()
      */
-    protected class Cache
+    protected static class Cache
     {
         /**
          *  <i>hash</i> is updated by the <i>statisticsUpdate</i>() method.
@@ -2792,7 +2791,7 @@ public class SparseBitSet implements Cloneable, Serializable
 
     //-----------------------------------------------------------------------------
     /**
-     *  Set creates entries everywhere within the range. Hence no empty level2
+     *  Set creates entries everywhere within the range. Hence, no empty level2
      *  areas or level3 blocks are ignored, and no empty (all zero) blocks are
      *  returned.
      *
@@ -2974,7 +2973,6 @@ public class SparseBitSet implements Cloneable, Serializable
          *  in sequential order of the words in the set for which the statistics
          *  are being accumulated, and only for non-null values of the second
          *  parameter.
-         *
          *  Two of the values (a2Count and a3Count) are not updated here,
          *  but are done in the code near where this method is called.
          *
@@ -3053,19 +3051,19 @@ public class SparseBitSet implements Cloneable, Serializable
     /**
      *  Word and block <b>and</b> strategy.
      */
-    protected static final transient AndStrategy andStrategy = new AndStrategy();
+    protected static final AndStrategy andStrategy = new AndStrategy();
     /**
      *  Word and block <b>andNot</b> strategy.
      */
-    protected static final transient AndNotStrategy andNotStrategy = new AndNotStrategy();
+    protected static final AndNotStrategy andNotStrategy = new AndNotStrategy();
     /**
      *  Word and block <b>clear</b> strategy.
      */
-    protected static final transient ClearStrategy clearStrategy = new ClearStrategy();
+    protected static final ClearStrategy clearStrategy = new ClearStrategy();
     /**
      *  Word and block <b>copy</b> strategy.
      */
-    protected static final transient CopyStrategy copyStrategy = new CopyStrategy();
+    protected static final CopyStrategy copyStrategy = new CopyStrategy();
     /**
      *  Word and block <b>equals</b> strategy.
      */
@@ -3073,19 +3071,19 @@ public class SparseBitSet implements Cloneable, Serializable
     /**
      *  Word and block <b>flip</b> strategy.
      */
-    protected static final transient FlipStrategy flipStrategy = new FlipStrategy();
+    protected static final FlipStrategy flipStrategy = new FlipStrategy();
     /**
      *  Word and block <b>intersects</b> strategy.
      */
-    protected static transient IntersectsStrategy intersectsStrategy = new IntersectsStrategy();
+    protected static final IntersectsStrategy intersectsStrategy = new IntersectsStrategy();
     /**
      *  Word and block <b>or</b> strategy.
      */
-    protected static final transient OrStrategy orStrategy = new OrStrategy();
+    protected static final OrStrategy orStrategy = new OrStrategy();
     /**
      *  Word and block <b>set</b> strategy.
      */
-    protected static final transient SetStrategy setStrategy = new SetStrategy();
+    protected static final SetStrategy setStrategy = new SetStrategy();
     /**
      *  Word and block <b>update</b> strategy.
      */
@@ -3093,5 +3091,5 @@ public class SparseBitSet implements Cloneable, Serializable
     /**
      *  Word and block <b>xor</b> strategy.
      */
-    protected static final transient XorStrategy xorStrategy = new XorStrategy();
+    protected static final XorStrategy xorStrategy = new XorStrategy();
 }

--- a/src/test/java/com/zaxxer/sparsebits/PreviousClearBitTest.java
+++ b/src/test/java/com/zaxxer/sparsebits/PreviousClearBitTest.java
@@ -25,28 +25,28 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void minusOne() throws Exception {
+    public void minusOne() {
         final int ret = set.previousClearBit(-1);
 
         assertEquals(-1, ret);
     }
 
     @Test
-    public void emptySet() throws Exception {
+    public void emptySet() {
         final int ret = set.previousClearBit(0);
 
         assertEquals(0, ret);
     }
 
     @Test
-    public void bottomBit() throws Exception {
+    public void bottomBit() {
         final int ret = set.previousClearBit(1);
 
         assertEquals(1, ret);
     }
 
     @Test
-    public void sameBit() throws Exception {
+    public void sameBit() {
         set.set(12345);
         final int ret = set.previousClearBit(12345);
 
@@ -54,7 +54,7 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void level1Miss() throws Exception {
+    public void level1Miss() {
         final int i = (1 << (SHIFT1 + SHIFT3));
         set.set(i);
         final int ret = set.previousClearBit(i);
@@ -63,7 +63,7 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void level1MissPlus1() throws Exception {
+    public void level1MissPlus1() {
         final int i = (1 << (SHIFT1 + SHIFT3)) + 1;
         set.set(i);
         final int ret = set.previousClearBit(i);
@@ -72,7 +72,7 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void level1MissMinus1() throws Exception {
+    public void level1MissMinus1() {
         final int i = (1 << (SHIFT1 + SHIFT3)) - 1;
         set.set(i);
         final int ret = set.previousClearBit(i);
@@ -81,7 +81,7 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void level2Miss() throws Exception {
+    public void level2Miss() {
         final int i = (1 << (SHIFT3 + SHIFT2));
         set.set(i);
         final int ret = set.previousClearBit(i);
@@ -90,7 +90,7 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void level2MissPlus1() throws Exception {
+    public void level2MissPlus1() {
         final int i = (1 << (SHIFT3 + SHIFT2)) + 1;
         set.set(i);
         final int ret = set.previousClearBit(i);
@@ -99,7 +99,7 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void level2MissMinus1() throws Exception {
+    public void level2MissMinus1() {
         final int i = (1 << (SHIFT3 + SHIFT2)) - 1;
         set.set(i);
         final int ret = set.previousClearBit(i);
@@ -108,7 +108,7 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void level3Miss() throws Exception {
+    public void level3Miss() {
         final int i = (1 << SHIFT3);
         set.set(i);
         final int ret = set.previousClearBit(i);
@@ -117,7 +117,7 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void level3MissPlus1() throws Exception {
+    public void level3MissPlus1() {
         final int i = (1 << SHIFT3) + 1;
         set.set(i);
         final int ret = set.previousClearBit(i);
@@ -126,7 +126,7 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void level3MissMinus1() throws Exception {
+    public void level3MissMinus1() {
         final int i = (1 << SHIFT3) - 1;
         set.set(i);
         final int ret = set.previousClearBit(i);
@@ -135,7 +135,7 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void noneBelow() throws Exception {
+    public void noneBelow() {
         set.set(1);
         final int ret = set.previousClearBit(1);
 
@@ -143,7 +143,7 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void oneBelow() throws Exception {
+    public void oneBelow() {
         set.set(1);
         final int ret = set.previousClearBit(2);
 
@@ -151,7 +151,7 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void threeNoSet() throws Exception {
+    public void threeNoSet() {
         set.set(1);
         final int ret = set.previousClearBit(3);
 
@@ -159,7 +159,7 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void threeSet() throws Exception {
+    public void threeSet() {
         set.set(3);
         final int ret = set.previousClearBit(3);
 
@@ -167,7 +167,7 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void topBit() throws Exception {
+    public void topBit() {
         final int i = Integer.MAX_VALUE - 1;
         final int ret = set.previousClearBit(i);
 
@@ -175,7 +175,7 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void randomSingleEntry() throws Exception {
+    public void randomSingleEntry() {
         final Random random = new Random(0);
         for (int i = 0; i < 10000; ++i) {
             set = new SparseBitSet();
@@ -186,9 +186,9 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void randomMultiEntry() throws Exception {
+    public void randomMultiEntry() {
         final Random random = new Random(0);
-        final Set<Integer> values = new HashSet<Integer>();
+        final Set<Integer> values = new HashSet<>();
         for (int i = 0; i < 10000; ++i) {
             set = new SparseBitSet();
             for (int j = 0; j < 1000; ++j) {
@@ -208,7 +208,7 @@ public class PreviousClearBitTest extends Assert {
     }
 
     @Test
-    public void bug15() throws Exception {
+    public void bug15() {
         set.set(1);
         set.set(64);
         assertEquals(63, set.previousClearBit(64));

--- a/src/test/java/com/zaxxer/sparsebits/PreviousSetBitTest.java
+++ b/src/test/java/com/zaxxer/sparsebits/PreviousSetBitTest.java
@@ -26,14 +26,14 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void emptySet() throws Exception {
+    public void emptySet() {
         final int ret = set.previousSetBit(0);
 
         assertEquals(-1, ret);
     }
 
     @Test
-    public void bottomBit() throws Exception {
+    public void bottomBit() {
         set.set(0);
         final int ret = set.previousSetBit(0);
 
@@ -41,7 +41,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void betweenTwo() throws Exception {
+    public void betweenTwo() {
         set.set(4);
         set.set(8);
         final int ret = set.previousSetBit(5);
@@ -50,7 +50,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void inRun() throws Exception {
+    public void inRun() {
         set.set(4);
         set.set(8);
         set.set(13);
@@ -62,7 +62,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void sameBit() throws Exception {
+    public void sameBit() {
         set.set(12345);
         final int ret = set.previousSetBit(12345);
 
@@ -70,7 +70,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void noneBelow() throws Exception {
+    public void noneBelow() {
         set.set(1);
         final int ret = set.previousSetBit(0);
 
@@ -78,7 +78,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void oneBelow() throws Exception {
+    public void oneBelow() {
         set.set(1);
         final int ret = set.previousSetBit(2);
 
@@ -86,7 +86,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void twoBelow() throws Exception {
+    public void twoBelow() {
         set.set(1);
         final int ret = set.previousSetBit(3);
 
@@ -94,7 +94,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void topBit() throws Exception {
+    public void topBit() {
         final int i = Integer.MAX_VALUE - 1;
         set.set(i);
         final int ret = set.previousSetBit(i);
@@ -103,7 +103,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void level1Miss() throws Exception {
+    public void level1Miss() {
         final int i = (1 << (SHIFT1 + SHIFT3));
         set.set(i - 1);
         final int ret = set.previousSetBit(i);
@@ -112,7 +112,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void level1MissPlus1() throws Exception {
+    public void level1MissPlus1() {
         final int i = (1 << (SHIFT1 + SHIFT3)) + 1;
         set.set(i - 1);
         final int ret = set.previousSetBit(i);
@@ -121,7 +121,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void level1MissMinus1() throws Exception {
+    public void level1MissMinus1() {
         final int i = (1 << (SHIFT1 + SHIFT3)) - 1;
         set.set(i - 1);
         final int ret = set.previousSetBit(i);
@@ -130,7 +130,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void level2Miss() throws Exception {
+    public void level2Miss() {
         final int i = (1 << (SHIFT3 + SHIFT2));
         set.set(i - 1);
         final int ret = set.previousSetBit(i);
@@ -139,7 +139,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void level2MissPlus1() throws Exception {
+    public void level2MissPlus1() {
         final int i = (1 << (SHIFT3 + SHIFT2)) + 1;
         set.set(i - 1);
         final int ret = set.previousSetBit(i);
@@ -148,7 +148,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void level2MissMinus1() throws Exception {
+    public void level2MissMinus1() {
         final int i = (1 << (SHIFT3 + SHIFT2)) - 1;
         set.set(i - 1);
         final int ret = set.previousSetBit(i);
@@ -157,7 +157,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void level3Miss() throws Exception {
+    public void level3Miss() {
         final int i = (1 << SHIFT3);
         set.set(i - 1);
         final int ret = set.previousSetBit(i);
@@ -166,7 +166,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void level3MissPlus1() throws Exception {
+    public void level3MissPlus1() {
         final int i = (1 << SHIFT3) + 1;
         set.set(i - 1);
         final int ret = set.previousSetBit(i);
@@ -175,7 +175,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void level3MissMinus1() throws Exception {
+    public void level3MissMinus1() {
         final int i = (1 << SHIFT3) - 1;
         set.set(i - 1);
         final int ret = set.previousSetBit(i);
@@ -184,7 +184,7 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void randomSingleEntry() throws Exception {
+    public void randomSingleEntry() {
         final int max = Integer.MAX_VALUE - 1;
         final Random random = new Random(0);
         for (int i = 0; i < 10000; ++i) {
@@ -197,18 +197,18 @@ public class PreviousSetBitTest extends Assert {
     }
 
     @Test
-    public void randomMultiEntry() throws Exception {
+    public void randomMultiEntry() {
         randomMultiEntry(Integer.MAX_VALUE);
     }
 
     @Test
-    public void randomMultiEntryTight() throws Exception {
+    public void randomMultiEntryTight() {
         randomMultiEntry(2000);
     }
 
-    public void randomMultiEntry(final int max) throws Exception {
+    public void randomMultiEntry(final int max) {
         final Random random = new Random(0);
-        final List<Integer> values = new ArrayList<Integer>();
+        final List<Integer> values = new ArrayList<>();
         for (int i = 0; i < 10000; ++i) {
             set = new SparseBitSet();
             for (int j = 0; j < 1000; ++j) {


### PR DESCRIPTION
remove redundant modifiers
remove exceptions that are never thrown
update dependencies that has vulnerabilities
fix some typos
code already uses string methods that are available since java 6, so I had to update java version from 1.5. I think its safe to use java 1.7

it addressess issue #17 