### PR TITLE
Remove call to Math.min

### DIFF
--- a/src/main/java/com/zaxxer/sparsebits/SparseBitSet.java
+++ b/src/main/java/com/zaxxer/sparsebits/SparseBitSet.java
@@ -1058,7 +1058,7 @@ public class SparseBitSet implements Cloneable, Serializable
         int w1 = w >> SHIFT1;
         if (w1 > aSize)
             return i;
-        w1 = Math.min(w1, aSize);
+
         int w4 = i % LENGTH4;
 
         long word;


### PR DESCRIPTION
Given the previous if statement w1 will always be less than or equal to aSize, therefore Math.min will always return the same value (w1)