### PR TITLE
add module-info instead of automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,29 +62,44 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.1</version>
+            <version>3.11.0</version>
             <configuration>
                <source>1.6</source>
                <target>1.6</target>
                <testSource>1.8</testSource>
                <testTarget>1.8</testTarget>
             </configuration>
+            <executions>
+               <execution>
+                  <id>default-compile</id>
+                  <configuration>
+                     <release>9</release>
+                     <!-- no excludes: compile everything to ensure module-info contains right entries -->
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>base-compile</id>
+                  <goals>
+                     <goal>compile</goal>
+                  </goals>
+                  <configuration>
+                     <!-- recompile everything for target VM except the module-info.java -->
+                     <excludes>
+                        <exclude>module-info.java</exclude>
+                     </excludes>
+                  </configuration>
+               </execution>
+            </executions>
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
-            <configuration>
-               <archive>
-                  <manifestEntries>
-                     <Automatic-Module-Name>com.zaxxer.sparsebitset</Automatic-Module-Name>
-                  </manifestEntries>
-               </archive>
-            </configuration>
+            <version>3.3.0</version>
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>2.2.1</version>
+            <version>3.3.0</version>
             <configuration>
                <attach>true</attach>
             </configuration>
@@ -100,7 +115,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.9.1</version>
+            <version>3.6.0</version>
             <configuration>
                <show>public</show>
                <attach>true</attach>
@@ -130,7 +145,7 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-gpg-plugin</artifactId>
-                  <version>1.4</version>
+                  <version>3.1.0</version>
                   <executions>
                      <execution>
                         <id>sign-artifacts</id>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+open module com.zaxxer.sparsebitset {
+    exports com.zaxxer.sparsebits;
+}


### PR DESCRIPTION
This PR adds a named module instead of an automatic module name. This is required to jlink compatibility.